### PR TITLE
minor css issues

### DIFF
--- a/src/components/multi_selection_list/multiselection_list.scss
+++ b/src/components/multi_selection_list/multiselection_list.scss
@@ -9,6 +9,9 @@ $list_font_size: $font-default;
 .multi_selection_list {
   color: $item_font_color;
   border: $border-1 solid $grey-350;
+  &:first-of-type {
+    border-right: 0;
+  }
 }
 
 .list_filter_container {

--- a/src/components/multi_selection_list/virtualized_items/multiselection_virtualized_items.scss
+++ b/src/components/multi_selection_list/virtualized_items/multiselection_virtualized_items.scss
@@ -4,10 +4,10 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  outline: none;
 }
 
 .no_items {
-  font-size: $font-default;
   font-size: $font-default;
   color: $grey-450;
   display: flex;

--- a/src/components/react_multi_select.js
+++ b/src/components/react_multi_select.js
@@ -22,7 +22,7 @@ import { FormControlLabel } from "material-ui/Form";
 import MultiSelectionList from "./multi_selection_list/multiselection_list";
 
 export const ITEMS_LIST_HEIGHT = 320;
-export const SELECTED_ITEMS_LIST_HEIGHT = 360;
+export const SELECTED_ITEMS_LIST_HEIGHT = 361;
 export const LIST_ROW_HEIGHT = 40;
 
 const displayItem = ({ isItemSelected }) => item => {

--- a/src/components/react_multi_select.scss
+++ b/src/components/react_multi_select.scss
@@ -15,7 +15,7 @@
   justify-content: space-between;
   border: $border-1 solid $grey-350;
   border-width: $border-1 $border-1 0 0;
-  height: $space-50;
+  height: $space-50 + 1;
   padding: 0 $space-20;
   align-items: center;
   font-size: 12px;


### PR DESCRIPTION
@AmirAsaraf @talyak 
This PR fixes some minor UI glitches.
The solution is a bit of a placeholder and I need to think of a long term solution for calculating the correct sizes.

Changes:
1. No duplicate border between the lists.
2. Both list have the same size now.
3. No outline indication on the grid selection

![image](https://user-images.githubusercontent.com/4344533/37700812-9355379c-2cf5-11e8-8697-b46b40160c9c.png)
