### PR TITLE
Remove buggy and strange behavior with double click.

### DIFF
--- a/src/components/multi_selection_list/multiselection_list.js
+++ b/src/components/multi_selection_list/multiselection_list.js
@@ -197,7 +197,6 @@ class MultiSelectionList extends PureComponent {
         key={item.id}
         onDragStart={this.selectItem(item)}
         onClick={this.toggleItemSelected(item)}
-        onDoubleClick={this.selectSingle(item)}
       >
         {this.props.displayFn(item)}
       </li>


### PR DESCRIPTION
Remove the bug with fast clicks of checkboxes caused to invert selection. 
Don't know who defined this behavior but it's the strangest I've ever met.