### PR TITLE
Add support for maxSelectedItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ class Example extends Component {
 | `wrapperClassName`              | `String`              | ''                                               | wrapper class name. Used for customizing the style
 | `height`                        | `number`              | 400                                              | available items list height
 | `itemHeight`                    | `number`              | 40                                               | the height of an item in the list
+| `maxSelectedItems`              | `number`              |                                                  | defines the maximum items that can be selected. Overrides showSelectAll
 | `filterFunction`                | `function`            | based on label                                   | The function used to filter items based on the search query
 | `searchRenderer`                | `Component`           |                                                  | Component to replace the default Search component
 | `selectedItemRenderer`          | `Component`           |                                                  | Component to replace the default selected item component in the destination list
@@ -111,6 +112,8 @@ Each item receives the following props:
 `checked` - indicates if the item is selected
 
 `indeterminate` - used by the select all component to display indeterminate mode
+
+`disabled` - defines if item should be disabled
 
 <br/>
 

--- a/src/components/items/item.js
+++ b/src/components/items/item.js
@@ -11,12 +11,14 @@ const Item = ({
   onClick,
   withBorder,
   checked,
-  indeterminate
+  indeterminate,
+  disabled
 }) => (
   <div
     className={classnames(styles.item, {
       [styles.with_border]: withBorder,
-      [styles.selected]: checked
+      [styles.selected]: checked,
+      [styles.disabled]: disabled
     })}
     style={{ height }}
     onClick={onClick}
@@ -26,6 +28,7 @@ const Item = ({
       color="primary"
       checked={checked}
       indeterminate={indeterminate}
+      disabled={disabled}
     />
     {item.label}
   </div>
@@ -36,7 +39,8 @@ Item.propTypes = {
   height: PropTypes.number,
   withBorder: PropTypes.bool,
   checked: PropTypes.bool,
-  indeterminate: PropTypes.bool
+  indeterminate: PropTypes.bool,
+  disabled: PropTypes.bool
 };
 
 Item.defaultProps = {
@@ -44,7 +48,8 @@ Item.defaultProps = {
   height: 40,
   withBorder: false,
   checked: false,
-  indeterminate: false
+  indeterminate: false,
+  disabled: false
 };
 
 export default Item;

--- a/src/components/items/item.scss
+++ b/src/components/items/item.scss
@@ -3,15 +3,20 @@
 .item {
   display: flex;
   align-items: center;
-  transition: background-color 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
   box-sizing: border-box;
   cursor: pointer;
   .selected {
     background-color: $selected-background-color;
   }
-  &:hover:not(.selected) {
+  &:hover:not(.selected, .disabled) {
     background-color: $hover-background-color;
   }
+}
+
+.disabled {
+  color: $disabled-color;
+  cursor: default;
 }
 
 .selected {

--- a/src/components/list/items_list.js
+++ b/src/components/list/items_list.js
@@ -13,7 +13,8 @@ class ItemsList extends PureComponent {
     offset: PropTypes.number,
     onClick: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.number),
-    items: PropTypes.array
+    items: PropTypes.array,
+    disabled: PropTypes.bool
   };
 
   static defaultProps = {
@@ -21,7 +22,8 @@ class ItemsList extends PureComponent {
     height: 400,
     offset: 0,
     selectedIds: [],
-    items: []
+    items: [],
+    disabled: false
   };
 
   constructor(props) {
@@ -48,7 +50,8 @@ class ItemsList extends PureComponent {
       noItemsRenderer,
       renderer,
       selectedIds,
-      onClick
+      onClick,
+      disabled
     } = this.props;
     return (
       <AutoSizer>
@@ -68,6 +71,7 @@ class ItemsList extends PureComponent {
             onClick={onClick}
             items={items}
             selectedIds={selectedIds}
+            disabled={disabled}
           />
         )}
       </AutoSizer>

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -15,7 +15,8 @@ class InnerList extends PureComponent {
     offset: PropTypes.number,
     onClick: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.number),
-    items: PropTypes.array
+    items: PropTypes.array,
+    disabled: PropTypes.bool
   };
 
   static defaultProps = {
@@ -25,16 +26,34 @@ class InnerList extends PureComponent {
     height: 400,
     offset: 0,
     selectedIds: [],
-    items: []
+    items: [],
+    disabled: false
   };
 
   constructor(props) {
     super(props);
     this.rowRenderer = this.rowRenderer.bind(this);
     this.noRowsRenderer = this.noRowsRenderer.bind(this);
+    this.onClick = this.onClick.bind(this);
   }
+
+  onClick(item) {
+    const { disabled, onClick, selectedIds } = this.props;
+    const checked = selectedIds.includes(item.id);
+    if ((disabled && checked) || !disabled) {
+      onClick(item.id);
+    }
+  }
+
   rowRenderer({ index, isScrolling, key, style }) {
-    const { renderer, itemHeight, onClick, items, selectedIds } = this.props;
+    const {
+      renderer,
+      itemHeight,
+      onClick,
+      items,
+      selectedIds,
+      disabled
+    } = this.props;
     const Renderer = renderer;
     const item = items[index];
     const checked = selectedIds.includes(item.id);
@@ -43,9 +62,14 @@ class InnerList extends PureComponent {
         key={key}
         style={style}
         className={styles.list_item}
-        onClick={() => onClick(item.id)}
+        onClick={() => this.onClick(item)}
       >
-        <Renderer item={item} height={itemHeight} checked={checked} />
+        <Renderer
+          item={item}
+          height={itemHeight}
+          checked={checked}
+          disabled={disabled && !checked}
+        />
       </div>
     );
   }

--- a/src/components/multi_select.js
+++ b/src/components/multi_select.js
@@ -24,7 +24,8 @@ export class MultiSelect extends PureComponent {
     selectedItemRenderer: PropTypes.any,
     height: PropTypes.number,
     itemHeight: PropTypes.number,
-    loaderRenderer: PropTypes.any
+    loaderRenderer: PropTypes.any,
+    maxSelectedItems: PropTypes.number
   };
 
   static defaultProps = {
@@ -39,8 +40,14 @@ export class MultiSelect extends PureComponent {
   };
 
   calculateHeight() {
-    let { height, showSearch, showSelectAll, itemHeight } = this.props;
-    height = showSearch ? height - 45 : height;
+    let {
+      height,
+      showSearch,
+      showSelectAll,
+      itemHeight,
+      maxSelectedItems
+    } = this.props;
+    height = showSearch && !maxSelectedItems ? height - 45 : height;
     height = showSelectAll ? height - itemHeight : height;
     return height;
   }
@@ -70,10 +77,13 @@ export class MultiSelect extends PureComponent {
       noItemsRenderer,
       loaderRenderer,
       messages,
-      loading
+      loading,
+      maxSelectedItems
     } = this.props;
     const calculatedHeight = this.calculateHeight();
     const selectedIds = selectedItems.map(item => item.id);
+    const disabled =
+      maxSelectedItems && maxSelectedItems <= selectedItems.length;
     const LoaderRenderer = loaderRenderer;
     return (
       <div
@@ -89,7 +99,7 @@ export class MultiSelect extends PureComponent {
             filterItems={filterItems}
             searchIcon={searchIcon}
             messages={messages}
-            showSelectAll={showSelectAll}
+            showSelectAll={showSelectAll && !maxSelectedItems}
             itemHeight={itemHeight}
             selectAllItems={selectAllItems}
             isAllSelected={isAllSelected}
@@ -100,6 +110,7 @@ export class MultiSelect extends PureComponent {
             calculatedHeight={calculatedHeight}
             selectItem={selectItem}
             noItemsRenderer={noItemsRenderer}
+            disabled={disabled}
           />
         )}
         {!loading && (

--- a/src/components/source_list.js
+++ b/src/components/source_list.js
@@ -25,7 +25,8 @@ const SourceList = ({
   filteredItems,
   calculatedHeight,
   selectItem,
-  noItemsRenderer
+  noItemsRenderer,
+  disabled
 }) => {
   const SearchRenderer = searchRenderer;
   const SelectAllRenderer = selectAllRenderer;
@@ -59,6 +60,7 @@ const SourceList = ({
         renderer={itemRenderer}
         noItemsRenderer={noItemsRenderer}
         noItemsMessage={messages.noItemsMessage}
+        disabled={disabled}
       />
     </Column>
   );
@@ -81,7 +83,8 @@ SourceList.propTypes = {
   selectedIds: PropTypes.arrayOf(PropTypes.number),
   selectAllItems: PropTypes.func,
   getList: PropTypes.func,
-  selectItem: PropTypes.func
+  selectItem: PropTypes.func,
+  disabled: PropTypes.bool
 };
 
 SourceList.defaultProps = {
@@ -96,7 +99,8 @@ SourceList.defaultProps = {
   itemHeight: 40,
   selectedIds: [],
   filteredItems: [],
-  messages: {}
+  messages: {},
+  disabled: false
 };
 
 export default SourceList;

--- a/src/resources/globals.scss
+++ b/src/resources/globals.scss
@@ -43,6 +43,7 @@ $default-color: $grey-600;
 $main-color: $color-black;
 $placeholder-color: $grey-450;
 $clickable-color: $blue-200;
+$disabled-color: $grey-420;
 
 $hover-background-color: $grey-200;
 $selected-background-color: $grey-100;

--- a/stories/multi-select.stories.js
+++ b/stories/multi-select.stories.js
@@ -49,6 +49,25 @@ storiesOf("React Multi Select", module)
       />
     );
   })
+  .add("With max selected items", () => {
+    const items = Array.apply(null, { length: 10 }).map((i, index) => {
+      return {
+        id: index,
+        label: `Item ${index}`
+      };
+    });
+
+    return (
+      <ReactMultiSelect
+        items={items}
+        maxSelectedItems={4}
+        loading={boolean("Loading", false)}
+        onChange={action("onChange")}
+        showSearch={boolean("Show search", true)}
+        showSelectAll={boolean("Show select all", true)}
+      />
+    );
+  })
   .add("With Custom Messages", () => {
     const items = Array.apply(null, { length: 10 }).map((i, index) => {
       return {

--- a/tests/components/__snapshots__/destination_list.spec.js.snap
+++ b/tests/components/__snapshots__/destination_list.spec.js.snap
@@ -10,6 +10,7 @@ exports[`DestinationList custom messages 1`] = `
     selectedMessage="Checked"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}
@@ -33,6 +34,7 @@ exports[`DestinationList custom noItemsRenderer 1`] = `
     selectedMessage="selected"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}
@@ -56,6 +58,7 @@ exports[`DestinationList custom selectedItemRenderer 1`] = `
     selectedMessage="selected"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}
@@ -79,6 +82,7 @@ exports[`DestinationList custom selectionStatusRenderer 1`] = `
     selectedMessage={undefined}
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}
@@ -102,6 +106,7 @@ exports[`DestinationList default snapshot 1`] = `
     selectedMessage="selected"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}
@@ -125,6 +130,7 @@ exports[`DestinationList passed clearAll 1`] = `
     selectedMessage="selected"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}
@@ -153,6 +159,7 @@ exports[`DestinationList passed selectedIds 1`] = `
     selectedMessage="selected"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}
@@ -176,6 +183,7 @@ exports[`DestinationList passed selectedItems 1`] = `
     selectedMessage="selected"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={
@@ -204,6 +212,7 @@ exports[`DestinationList passed unselectItem 1`] = `
     selectedMessage="selected"
   />
   <ItemsList
+    disabled={false}
     height={355}
     itemHeight={40}
     items={Array []}

--- a/tests/components/__snapshots__/multi_select.spec.js.snap
+++ b/tests/components/__snapshots__/multi_select.spec.js.snap
@@ -11,6 +11,7 @@ exports[`MultiSelect can remove search 1`] = `
 >
   <SourceList
     calculatedHeight={360}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -54,6 +55,7 @@ exports[`MultiSelect can remove select all 1`] = `
 >
   <SourceList
     calculatedHeight={355}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -97,6 +99,7 @@ exports[`MultiSelect custom itemRenderer 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -140,6 +143,7 @@ exports[`MultiSelect custom messages 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -201,6 +205,7 @@ exports[`MultiSelect custom noItemsRenderer 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -244,6 +249,7 @@ exports[`MultiSelect custom searchRenderer 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -287,6 +293,7 @@ exports[`MultiSelect custom selectAllRenderer 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -330,6 +337,7 @@ exports[`MultiSelect default snapshot 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -388,6 +396,65 @@ exports[`MultiSelect displays custom Loader when loading 1`] = `
 </div>
 `;
 
+exports[`MultiSelect does not pass disabled if maxSelectedItem has passed 1`] = `
+<div
+  className="wrapper"
+  style={
+    Object {
+      "height": 400,
+    }
+  }
+>
+  <SourceList
+    calculatedHeight={360}
+    disabled={false}
+    filterItems={undefined}
+    filteredItems={Array []}
+    getList={undefined}
+    isAllSelected={false}
+    itemHeight={40}
+    itemRenderer={[Function]}
+    messages={Object {}}
+    noItemsRenderer={[Function]}
+    searchIcon={undefined}
+    searchRenderer={[Function]}
+    selectAllItems={undefined}
+    selectAllRenderer={[Function]}
+    selectItem={undefined}
+    selectedIds={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+    showSearch={true}
+    showSelectAll={false}
+  />
+  <DestinationList
+    clearAll={undefined}
+    height={400}
+    itemHeight={40}
+    messages={Object {}}
+    noItemsRenderer={[Function]}
+    selectedIds={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+    selectedItemRenderer={[Function]}
+    selectedItems={
+      Array [
+        1,
+        2,
+      ]
+    }
+    selectionStatusRenderer={[Function]}
+    unselectItem={undefined}
+  />
+</div>
+`;
+
 exports[`MultiSelect passed clearAll 1`] = `
 <div
   className="wrapper"
@@ -399,6 +466,7 @@ exports[`MultiSelect passed clearAll 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -442,6 +510,7 @@ exports[`MultiSelect passed filterItems 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -485,6 +554,7 @@ exports[`MultiSelect passed selectAllItems 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -528,6 +598,7 @@ exports[`MultiSelect passed selectItem 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -571,6 +642,7 @@ exports[`MultiSelect passed selectedIds 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -614,6 +686,7 @@ exports[`MultiSelect passed selectedItems 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -672,6 +745,7 @@ exports[`MultiSelect passed unselectItem 1`] = `
 >
   <SourceList
     calculatedHeight={315}
+    disabled={false}
     filterItems={undefined}
     filteredItems={Array []}
     getList={undefined}
@@ -700,6 +774,65 @@ exports[`MultiSelect passed unselectItem 1`] = `
     selectedItems={Array []}
     selectionStatusRenderer={[Function]}
     unselectItem={[MockFunction unselectItem]}
+  />
+</div>
+`;
+
+exports[`MultiSelect passes disabled if maxSelectedItem has passed 1`] = `
+<div
+  className="wrapper"
+  style={
+    Object {
+      "height": 400,
+    }
+  }
+>
+  <SourceList
+    calculatedHeight={360}
+    disabled={true}
+    filterItems={undefined}
+    filteredItems={Array []}
+    getList={undefined}
+    isAllSelected={false}
+    itemHeight={40}
+    itemRenderer={[Function]}
+    messages={Object {}}
+    noItemsRenderer={[Function]}
+    searchIcon={undefined}
+    searchRenderer={[Function]}
+    selectAllItems={undefined}
+    selectAllRenderer={[Function]}
+    selectItem={undefined}
+    selectedIds={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+    showSearch={true}
+    showSelectAll={false}
+  />
+  <DestinationList
+    clearAll={undefined}
+    height={400}
+    itemHeight={40}
+    messages={Object {}}
+    noItemsRenderer={[Function]}
+    selectedIds={
+      Array [
+        undefined,
+        undefined,
+      ]
+    }
+    selectedItemRenderer={[Function]}
+    selectedItems={
+      Array [
+        1,
+        2,
+      ]
+    }
+    selectionStatusRenderer={[Function]}
+    unselectItem={undefined}
   />
 </div>
 `;

--- a/tests/components/__snapshots__/source_list.spec.js.snap
+++ b/tests/components/__snapshots__/source_list.spec.js.snap
@@ -11,6 +11,7 @@ exports[`SourceList can remove search 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -32,6 +33,7 @@ exports[`SourceList can remove select all 1`] = `
     searchPlaceholder="Search..."
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -61,6 +63,7 @@ exports[`SourceList custom itemRenderer 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -90,6 +93,7 @@ exports[`SourceList custom messages 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -119,6 +123,7 @@ exports[`SourceList custom noItemsRenderer 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -148,6 +153,7 @@ exports[`SourceList custom searchRenderer 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -177,6 +183,7 @@ exports[`SourceList custom selectAllRenderer 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -206,6 +213,7 @@ exports[`SourceList default snapshot 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -235,6 +243,7 @@ exports[`SourceList passed filterItems 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -264,6 +273,7 @@ exports[`SourceList passed selectAllItems 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -293,6 +303,7 @@ exports[`SourceList passed selectItem 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -327,6 +338,7 @@ exports[`SourceList passed selectedIds 1`] = `
     }
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}
@@ -361,6 +373,7 @@ exports[`SourceList passed selectedItems 1`] = `
     selectedIds={Array []}
   />
   <ItemsList
+    disabled={false}
     height={400}
     itemHeight={40}
     items={Array []}

--- a/tests/components/items/__snapshots__/item.spec.js.snap
+++ b/tests/components/items/__snapshots__/item.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Item default snapshot 1`] = `
   <WithStyles(Checkbox)
     checked={false}
     color="primary"
+    disabled={false}
     indeterminate={false}
     type="checkbox"
   />
@@ -32,6 +33,7 @@ exports[`Item snapshot with border 1`] = `
   <WithStyles(Checkbox)
     checked={false}
     color="primary"
+    disabled={false}
     indeterminate={false}
     type="checkbox"
   />
@@ -51,6 +53,27 @@ exports[`Item snapshot with checked status 1`] = `
   <WithStyles(Checkbox)
     checked={true}
     color="primary"
+    disabled={false}
+    indeterminate={false}
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`Item snapshot with disabled 1`] = `
+<div
+  className="item disabled"
+  onClick={undefined}
+  style={
+    Object {
+      "height": 40,
+    }
+  }
+>
+  <WithStyles(Checkbox)
+    checked={false}
+    color="primary"
+    disabled={true}
     indeterminate={false}
     type="checkbox"
   />
@@ -70,6 +93,7 @@ exports[`Item snapshot with height 1`] = `
   <WithStyles(Checkbox)
     checked={false}
     color="primary"
+    disabled={false}
     indeterminate={false}
     type="checkbox"
   />
@@ -89,6 +113,7 @@ exports[`Item snapshot with indeterminate and checked status 1`] = `
   <WithStyles(Checkbox)
     checked={true}
     color="primary"
+    disabled={false}
     indeterminate={true}
     type="checkbox"
   />
@@ -108,6 +133,7 @@ exports[`Item snapshot with indeterminate status 1`] = `
   <WithStyles(Checkbox)
     checked={false}
     color="primary"
+    disabled={false}
     indeterminate={true}
     type="checkbox"
   />
@@ -127,6 +153,7 @@ exports[`Item snapshot with valid item 1`] = `
   <WithStyles(Checkbox)
     checked={false}
     color="primary"
+    disabled={false}
     indeterminate={false}
     type="checkbox"
   />

--- a/tests/components/items/__snapshots__/select_all.spec.js.snap
+++ b/tests/components/items/__snapshots__/select_all.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`SelectAll default snapshot 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={false}
   item={
@@ -18,6 +19,7 @@ exports[`SelectAll default snapshot 1`] = `
 exports[`SelectAll snapshot with empty selectedIds with select all 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={false}
   item={
@@ -33,6 +35,7 @@ exports[`SelectAll snapshot with empty selectedIds with select all 1`] = `
 exports[`SelectAll snapshot with empty selectedIds without select all 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={false}
   item={
@@ -48,6 +51,7 @@ exports[`SelectAll snapshot with empty selectedIds without select all 1`] = `
 exports[`SelectAll snapshot with height 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={20}
   indeterminate={false}
   item={
@@ -63,6 +67,7 @@ exports[`SelectAll snapshot with height 1`] = `
 exports[`SelectAll snapshot with isSelectAll 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={false}
   item={
@@ -78,6 +83,7 @@ exports[`SelectAll snapshot with isSelectAll 1`] = `
 exports[`SelectAll snapshot with isSelectAll false 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={false}
   item={
@@ -93,6 +99,7 @@ exports[`SelectAll snapshot with isSelectAll false 1`] = `
 exports[`SelectAll snapshot with selectAllMessage 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={false}
   item={
@@ -108,6 +115,7 @@ exports[`SelectAll snapshot with selectAllMessage 1`] = `
 exports[`SelectAll snapshot with selectedIds with select all should be indeterminate 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={true}
   item={
@@ -123,6 +131,7 @@ exports[`SelectAll snapshot with selectedIds with select all should be indetermi
 exports[`SelectAll snapshot with selectedIds without select all should be indeterminate 1`] = `
 <Item
   checked={false}
+  disabled={false}
   height={40}
   indeterminate={true}
   item={

--- a/tests/components/items/item.spec.js
+++ b/tests/components/items/item.spec.js
@@ -43,6 +43,12 @@ describe("Item", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test("snapshot with disabled", () => {
+    const renderer = new ShallowRenderer();
+    const tree = renderer.render(<Item disabled={true} />);
+    expect(tree).toMatchSnapshot();
+  });
+
   test("snapshot with height", () => {
     const renderer = new ShallowRenderer();
     const tree = renderer.render(<Item height={20} />);

--- a/tests/components/list/list.spec.js
+++ b/tests/components/list/list.spec.js
@@ -105,4 +105,30 @@ describe("List", () => {
     itemsWrapper.at(0).simulate("click");
     expect(onClick).toHaveBeenCalledWith(5);
   });
+
+  test("click will not trigger onClick if disabled", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <List width={100} items={items} onClick={onClick} disabled={true} />
+    );
+    const itemsWrapper = wrapper.find(Item);
+    itemsWrapper.at(0).simulate("click");
+    expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  test("click will trigger onClick if disabled but also checked", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <List
+        width={100}
+        items={items}
+        selectedIds={[5]}
+        onClick={onClick}
+        disabled={true}
+      />
+    );
+    const itemsWrapper = wrapper.find(Item);
+    itemsWrapper.at(0).simulate("click");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/components/multi_select.spec.js
+++ b/tests/components/multi_select.spec.js
@@ -79,6 +79,18 @@ describe("MultiSelect", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test("passes disabled if maxSelectedItem has passed", () => {
+    const renderer = new ShallowRenderer();
+    const tree = renderer.render(<MultiSelect selectedItems={[1, 2]} maxSelectedItems={2}/>);
+    expect(tree).toMatchSnapshot();
+  });
+
+  test("does not pass disabled if maxSelectedItem has passed", () => {
+    const renderer = new ShallowRenderer();
+    const tree = renderer.render(<MultiSelect selectedItems={[1, 2]} maxSelectedItems={4}/>);
+    expect(tree).toMatchSnapshot();
+  });
+
   test("passed selectAllItems", () => {
     const renderer = new ShallowRenderer();
     const tree = renderer.render(


### PR DESCRIPTION
Fixes #59

## Proposed Changes
The following change adds support for a new prop - maxSelectedItems.
When given a number, it will override the showSelectAll and define it as false.
When selecting items as the number that was defined in maxSelectedItems the other items will be disabled.
Checked items can still be unchecked.
![image](https://user-images.githubusercontent.com/4344533/37863836-1ab4ab78-2f76-11e8-86ab-4dd148d56ce3.png)

