### PR TITLE
Adding item.disabled property to disable checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ class Example extends Component {
       items: [
         { id: 0, label: "item 1" },
         { id: 2, label: "item 2" },
-        { id: 3, label: "item 3" },
-        { id: 4, label: "item 4" }
+        { id: 3, label: "item 3", disabled: true }, // optional 'disabled' property
+        { id: 4, label: "item 4" , disabled: false}
       ],
       selectedItems: []
     };
@@ -107,7 +107,7 @@ Use the `itemRenderer` to replace the default component.
 
 Each item receives the following props:
 
-`item` - holds your item data
+`item` - holds your item data { id, label, disabled }
 
 `height` - receives the height defined by the list
 
@@ -193,6 +193,22 @@ Does not receive any props.
 **No Items**
 
 Use the `noItemsRenderer` to replace the default component.
+
+Does not receive any props.
+
+<br/>
+
+**Disabling Checkboxes via 'items' list**
+
+Along with the 'disabled' prop in the Item renderer, checkboxes can also be disabled via an optional 'disabled' property in the 'items' list.
+```javascript
+items: [
+        { id: 0, label: "item 1" },
+        { id: 2, label: "item 2" },
+        { id: 3, label: "item 3", disabled: true },
+        { id: 4, label: "item 4" , disabled: false}
+      ]
+```
 
 Does not receive any props.
 

--- a/src/components/items/item.js
+++ b/src/components/items/item.js
@@ -29,7 +29,7 @@ const Item = ({
       color="primary"
       checked={checked}
       indeterminate={indeterminate}
-      disabled={disabled}
+      disabled={disabled || item.disabled}
     />
     <ItemLabel label={item.label} />
   </div>

--- a/src/components/items/item.js
+++ b/src/components/items/item.js
@@ -29,7 +29,7 @@ const Item = ({
       color="primary"
       checked={checked}
       indeterminate={indeterminate}
-      disabled={disabled || item.disabled}
+      disabled={disabled || (item.disabled === true)}
     />
     <ItemLabel label={item.label} />
   </div>

--- a/src/components/items/item.js
+++ b/src/components/items/item.js
@@ -29,7 +29,7 @@ const Item = ({
       color="primary"
       checked={checked}
       indeterminate={indeterminate}
-      disabled={disabled || (item.disabled === true)}
+      disabled={disabled || item.disabled === true}
     />
     <ItemLabel label={item.label} />
   </div>

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -38,11 +38,11 @@ class InnerList extends PureComponent {
     this.onClick = this.onClick.bind(this);
   }
 
-  onClick(event, id) {
+  onClick(event, item) {
     const { disabled, onClick, selectedIds } = this.props;
-    const checked = selectedIds.includes(id);
-    if ((disabled && checked) || !disabled) {
-      onClick(event, id);
+    const checked = selectedIds.includes(item.id);
+    if (((disabled || item.disabled) && checked) || (!disabled && item.disabled !== true)) {
+      onClick(event, item.id);
     }
   }
 
@@ -64,14 +64,14 @@ class InnerList extends PureComponent {
         key={key}
         style={style}
         className={styles.list_item}
-        onClick={event => this.onClick(event, item.id)}
+        onClick={event => this.onClick(event, item)}
         title={disabled ? disabledItemsTooltip : undefined}
       >
         <Renderer
           item={item}
           height={itemHeight}
           checked={checked}
-          disabled={disabled && !checked}
+          disabled={(disabled || item.disabled === true) && !checked}
         />
       </div>
     );

--- a/tests/components/list/list.spec.js
+++ b/tests/components/list/list.spec.js
@@ -7,6 +7,10 @@ import NoItems from "../../../src/components/items/no_items";
 import ShallowRenderer from "react-test-renderer/shallow";
 
 const items = [{ id: 5, label: "item 0" }, { id: 12, label: "item 1" }];
+const disabledItems = [
+  { id: 5, label: "item 0", disabled: true },
+  { id: 12, label: "item 1", disabled: true }
+];
 const CUSTOM_MESSAGE = "custom message";
 const CustomComponent = () => <div>Custom Component</div>;
 
@@ -125,6 +129,31 @@ describe("List", () => {
         selectedIds={[5]}
         onClick={onClick}
         disabled={true}
+      />
+    );
+    const itemsWrapper = wrapper.find(Item);
+    itemsWrapper.at(0).simulate("click");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("click will not trigger onClick if disabled with item.disabled property", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <List width={100} items={disabledItems} onClick={onClick} />
+    );
+    const itemsWrapper = wrapper.find(Item);
+    itemsWrapper.at(0).simulate("click");
+    expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  test("click will trigger onClick if disabled with item.disabled property but also checked", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <List
+        width={100}
+        items={disabledItems}
+        selectedIds={[5]}
+        onClick={onClick}
       />
     );
     const itemsWrapper = wrapper.find(Item);


### PR DESCRIPTION
Fixes #

## Proposed Changes

I would like to add the ability to set checkboxes as disabled through an optional 'disabled' property in the Item.item.  In this way the passed List of 'items' from the user can be formatted as 

items: [
        { id: 0, label: "item 1", disabled: false },
        { id: 2, label: "item 2", disabled: true },
        { id: 3, label: "item 3", disabled: false },
        { id: 4, label: "item 4" },
        { id: 5, label: "item 5" }
      ],

This helps the user manage the checkboxes corresponding to their items List directly in the structure without having to do additional work aside from set a new propery.  This is helpful for React apps that do a lot of back end calls since the 'disabled' property can dynamically be added to the List item if an item needs to be disabled.

This is added as a new addition of (item.disabled === true), which will only set the checkbox to 'disabled' if the item was passed a disabled property and the passed property is true.
  -
  -
  -
