### PR TITLE
export default components

### DIFF
--- a/src/components/destination_list.js
+++ b/src/components/destination_list.js
@@ -73,4 +73,5 @@ DestinationList.defaultProps = {
   withGrouping: false
 };
 
+export { SelectedItem };
 export default DestinationList;

--- a/src/components/multi_select.js
+++ b/src/components/multi_select.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import withMultiSelectState from "./multi_select_state";
 import withResponsiveHeight from "./with_responsive_height";
 import SourceList from "./source_list";
-import DestinationList from "./destination_list";
+import DestinationList, { SelectedItem } from "./destination_list";
 
 import styles from "./multi_select.scss";
 import Loader from "./loader/loader";
@@ -150,4 +150,5 @@ export class MultiSelect extends PureComponent {
   }
 }
 
+export { SelectedItem, DestinationList, SourceList };
 export default withResponsiveHeight(withMultiSelectState(MultiSelect));

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,8 @@
-export { default } from "./components/multi_select";
+import MultiSelect, {
+  SelectedItem,
+  DestinationList,
+  SourceList
+} from "./components/multi_select";
+
+export { SelectedItem, DestinationList, SourceList };
+export default MultiSelect;


### PR DESCRIPTION
## Proposed Changes

  - export default components so that we can compose behaviours based on them

## Notes

I have huge difficulties running this locally, I tried to install an npm package to show reorder of elems but it crash, I thought it was a node version problem but apparently not.

I have tried to install the package locally from another project but I have a "window is undefined".

So I propose to merge this PR, build the package so that I can install it and make an example with sortable-js.
  
