### PR TITLE
Destination list height is not depends of search bar enable/disable

### DIFF
--- a/src/components/destination_list.js
+++ b/src/components/destination_list.js
@@ -23,12 +23,14 @@ const DestinationList = ({
   withGrouping,
   filteredItems,
   children,
-  isLocked
+  isLocked,
+  showSearch
 }) => {
   const SelectionStatusRenderer = selectionStatusRenderer;
   const updatedSelectedItems = withGrouping
     ? groupItems(filteredItems)
     : filteredItems;
+  const calculatedHeight = showSearch ? height - 90 : height - 45;
 
   return (
     <Column>
@@ -43,7 +45,7 @@ const DestinationList = ({
       <ItemsList
         items={updatedSelectedItems}
         itemHeight={itemHeight}
-        height={height - 45}
+        height={calculatedHeight}
         onClick={(event, id) => unselectItems([id])}
         renderer={selectedItemRenderer}
         noItemsRenderer={noItemsRenderer}
@@ -67,7 +69,8 @@ DestinationList.propTypes = {
   withGrouping: PropTypes.bool,
   filteredItems: PropTypes.arrayOf(PropTypes.object),
   children: PropTypes.node,
-  isLocked: PropTypes.func
+  isLocked: PropTypes.func,
+  showSearch: PropTypes.bool
 };
 
 DestinationList.defaultProps = {
@@ -80,7 +83,8 @@ DestinationList.defaultProps = {
   selectedItemRenderer: SelectedItem,
   noItemsRenderer: NoItems,
   withGrouping: false,
-  filteredItems: []
+  filteredItems: [],
+  showSearch: false
 };
 
 export { DestinationList };

--- a/src/components/with_search.js
+++ b/src/components/with_search.js
@@ -12,7 +12,7 @@ const withSearch = WrappedComponent => ({
 }) => {
   const SearchRenderer = searchRenderer;
   return (
-    <WrappedComponent {...others} messages={messages}>
+    <WrappedComponent {...others} messages={messages} showSearch={showSearch}>
       {showSearch && (
         <SearchRenderer
           onChange={filterItems}


### PR DESCRIPTION
## Steps to Reproduce the Problem
1. Set `showSelectedItemsSearch` to`true`
2. Choose 8 items in the Source list

**Destination list** height calculating without search component height.
If `showSelectedItemsSearch` is `true` the **Destination list** height will have no changes, as a result **Destination list** will have a bug with the displaying last added item.
![ScreenCaptureProject75](https://user-images.githubusercontent.com/10964198/61006298-ab79db80-a372-11e9-9112-395f0b1d50a7.gif)

## Proposed Changes
1. Pass `showSelectedItemsSearch` prop to `DestinationList` component to calculate list height in depense on `showSelectedItemsSearch` true/false
2. Calculate height of **Destination list** based on `showSelectedItemsSearch` true/false
